### PR TITLE
fix: typo "sonyflake" -> "cuid"

### DIFF
--- a/src/cuid.rs
+++ b/src/cuid.rs
@@ -4,12 +4,10 @@ use cuid;
 /// Generate a random cuid UUID
 #[pg_extern]
 fn idkit_cuid_generate() -> String {
-    let generated = cuid::cuid();
-    if let Err(e) = generated {
-        error!("{}", format!("failed to generate sonyflake: {}", e));
+    match cuid::cuid() {
+        Err(e) => error!("failed to generate cuid: {}", e),
+        Ok(id) => id,
     }
-
-    generated.unwrap()
 }
 
 //////////


### PR DESCRIPTION
I adjusted the idiom as while the optimizer might see through it and merge the checks, in pure Rust semantics this code can execute the check done in `if let Err` twice, as `unwrap` is internally
```rust
match result {
    Ok(o) => o,
    Err(e) => panic!("called `Result::unwrap()` on an `Err` value: {:?}", e),
}
```

and `if let Enum::Variant(inner) = enumeration { code_using(inner); }` is functionally sugar for
```rust
match enumeration {
    Enum::Variant(inner) => {
        code_using(inner);
        ()
    }
    _ignored => (),
}
```